### PR TITLE
feat: join channel by invitation

### DIFF
--- a/core/src/main/java/com/nailseong/invitation/event/Event.java
+++ b/core/src/main/java/com/nailseong/invitation/event/Event.java
@@ -1,0 +1,4 @@
+package com.nailseong.invitation.event;
+
+public abstract class Event {
+}

--- a/core/src/main/java/com/nailseong/invitation/event/EventConfig.java
+++ b/core/src/main/java/com/nailseong/invitation/event/EventConfig.java
@@ -1,0 +1,21 @@
+package com.nailseong.invitation.event;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EventConfig {
+
+    private final ApplicationContext applicationContext;
+
+    public EventConfig(final ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Bean
+    public InitializingBean eventsInitializer() {
+        return () -> Events.setPublisher(applicationContext);
+    }
+}

--- a/core/src/main/java/com/nailseong/invitation/event/Events.java
+++ b/core/src/main/java/com/nailseong/invitation/event/Events.java
@@ -1,0 +1,18 @@
+package com.nailseong.invitation.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class Events {
+
+    private static ApplicationEventPublisher publisher;
+
+    static void setPublisher(final ApplicationEventPublisher publisher) {
+        Events.publisher = publisher;
+    }
+
+    public static void raise(final Event event) {
+        if (publisher != null) {
+            publisher.publishEvent(event);
+        }
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/ChannelService.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/ChannelService.java
@@ -2,7 +2,6 @@ package com.nailseong.invitation.channel.application;
 
 import com.nailseong.invitation.channel.domain.Channel;
 import com.nailseong.invitation.channel.domain.ChannelMember;
-import com.nailseong.invitation.channel.domain.ChannelMemberRepository;
 import com.nailseong.invitation.channel.domain.ChannelRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,21 +10,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ChannelService {
 
-    private final ChannelRepository channelRepo;
-    private final ChannelMemberRepository channelMemberRepo;
+    private final ChannelRepository channelRepository;
 
-    public ChannelService(final ChannelRepository channelRepo,
-                          final ChannelMemberRepository channelMemberRepo) {
-        this.channelRepo = channelRepo;
-        this.channelMemberRepo = channelMemberRepo;
+    public ChannelService(final ChannelRepository channelRepository) {
+        this.channelRepository = channelRepository;
     }
 
     public Long createChannel(final Long memberId, final String nickname, final int maxPeople) {
-        final Channel channel = channelRepo.save(Channel.ofNew(memberId, maxPeople));
-
-        final ChannelMember host = ChannelMember.ofHost(channel.getId(), memberId, nickname);
-        channelMemberRepo.save(host);
-
-        return channel.getId();
+        final ChannelMember host = ChannelMember.ofHost(memberId, nickname);
+        final Channel channel = Channel.ofNew(memberId, maxPeople, host);
+        return channelRepository.saveChannel(channel)
+                .getId();
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
@@ -2,11 +2,8 @@ package com.nailseong.invitation.channel.application;
 
 import com.nailseong.invitation.channel.domain.Channel;
 import com.nailseong.invitation.channel.domain.ChannelMember;
-import com.nailseong.invitation.channel.domain.ChannelMemberRepository;
 import com.nailseong.invitation.channel.domain.ChannelRepository;
-import com.nailseong.invitation.channel.exception.ChannelNotFoundException;
 import com.nailseong.invitation.invitation.domain.InvitationUsedEvent;
-import java.util.List;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
@@ -14,23 +11,17 @@ import org.springframework.stereotype.Service;
 public class InvitationUsedEventHandler {
 
     private final ChannelRepository channelRepo;
-    private final ChannelMemberRepository channelMemberRepo;
 
-    public InvitationUsedEventHandler(final ChannelRepository channelRepo,
-                                      final ChannelMemberRepository channelMemberRepo) {
+    public InvitationUsedEventHandler(final ChannelRepository channelRepo) {
         this.channelRepo = channelRepo;
-        this.channelMemberRepo = channelMemberRepo;
     }
 
     @EventListener(InvitationUsedEvent.class)
     public void handle(final InvitationUsedEvent event) {
-        final Channel channel = channelRepo.findById(event.getChannelId())
-                .orElseThrow(ChannelNotFoundException::new);
-        final List<ChannelMember> channelMembers = channelMemberRepo.findAllByChannelId(event.getChannelId());
-        channel.setChannelMembers(channelMembers);
+        final Channel channel = channelRepo.getById(event.getChannelId());
         channel.join(event.getGuestId(), event.getNickname());
 
-        channelMemberRepo.save(ChannelMember.ofGuest(
+        channelRepo.saveMember(ChannelMember.ofGuest(
                 event.getChannelId(),
                 event.getGuestId(),
                 event.getNickname()

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
@@ -6,8 +6,10 @@ import com.nailseong.invitation.channel.domain.ChannelRepository;
 import com.nailseong.invitation.invitation.domain.InvitationUsedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class InvitationUsedEventHandler {
 
     private final ChannelRepository channelRepo;

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
@@ -1,0 +1,42 @@
+package com.nailseong.invitation.channel.application;
+
+import com.nailseong.invitation.channel.domain.ChannelMember;
+import com.nailseong.invitation.channel.domain.ChannelMemberRepository;
+import com.nailseong.invitation.channel.exception.AlreadyJoinException;
+import com.nailseong.invitation.invitation.domain.InvitationUsedEvent;
+import java.util.List;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InvitationUsedEventHandler {
+
+    private final ChannelMemberRepository channelMemberRepo;
+
+    public InvitationUsedEventHandler(final ChannelMemberRepository channelMemberRepo) {
+        this.channelMemberRepo = channelMemberRepo;
+    }
+
+    @EventListener(InvitationUsedEvent.class)
+    public void handle(final InvitationUsedEvent event) {
+        final List<ChannelMember> channelMembers = channelMemberRepo.findAllByChannelId(event.getChannelId());
+        if (isJoinedGuest(channelMembers, event.getGuestId())) {
+            throw new AlreadyJoinException();
+        }
+
+        // TODO: 2022/12/09 닉네임 중복 검사
+
+        final ChannelMember guest = ChannelMember.ofGuest(
+                event.getChannelId(),
+                event.getGuestId(),
+                event.getNickname()
+        );
+        channelMemberRepo.save(guest);
+    }
+
+    private boolean isJoinedGuest(final List<ChannelMember> channelMembers, final Long guestId) {
+        return channelMembers
+                .stream()
+                .anyMatch(it -> it.isSameMember(guestId));
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
@@ -4,9 +4,7 @@ import com.nailseong.invitation.channel.domain.Channel;
 import com.nailseong.invitation.channel.domain.ChannelMember;
 import com.nailseong.invitation.channel.domain.ChannelMemberRepository;
 import com.nailseong.invitation.channel.domain.ChannelRepository;
-import com.nailseong.invitation.channel.exception.AlreadyJoinException;
 import com.nailseong.invitation.channel.exception.ChannelNotFoundException;
-import com.nailseong.invitation.channel.exception.DuplicateNicknameException;
 import com.nailseong.invitation.invitation.domain.InvitationUsedEvent;
 import java.util.List;
 import org.springframework.context.event.EventListener;
@@ -28,34 +26,14 @@ public class InvitationUsedEventHandler {
     public void handle(final InvitationUsedEvent event) {
         final Channel channel = channelRepo.findById(event.getChannelId())
                 .orElseThrow(ChannelNotFoundException::new);
-        channel.join();
-
         final List<ChannelMember> channelMembers = channelMemberRepo.findAllByChannelId(event.getChannelId());
-        if (isJoinedGuest(channelMembers, event.getGuestId())) {
-            throw new AlreadyJoinException();
-        }
+        channel.setChannelMembers(channelMembers);
+        channel.join(event.getGuestId(), event.getNickname());
 
-        if (isDuplicatedNickname(channelMembers, event.getNickname())) {
-            throw new DuplicateNicknameException();
-        }
-
-        final ChannelMember guest = ChannelMember.ofGuest(
+        channelMemberRepo.save(ChannelMember.ofGuest(
                 event.getChannelId(),
                 event.getGuestId(),
                 event.getNickname()
-        );
-        channelMemberRepo.save(guest);
-    }
-
-    private boolean isJoinedGuest(final List<ChannelMember> channelMembers, final Long guestId) {
-        return channelMembers
-                .stream()
-                .anyMatch(it -> it.isSameMember(guestId));
-    }
-
-    private boolean isDuplicatedNickname(final List<ChannelMember> channelMembers, final String nickname) {
-        return channelMembers
-                .stream()
-                .anyMatch(it -> it.isSameNickname(nickname));
+        ));
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/application/InvitationUsedEventHandler.java
@@ -21,12 +21,7 @@ public class InvitationUsedEventHandler {
     @EventListener(InvitationUsedEvent.class)
     public void handle(final InvitationUsedEvent event) {
         final Channel channel = channelRepo.getById(event.getChannelId());
-        channel.join(event.getGuestId(), event.getNickname());
-
-        channelRepo.saveMember(ChannelMember.ofGuest(
-                event.getChannelId(),
-                event.getGuestId(),
-                event.getNickname()
-        ));
+        final ChannelMember joinedGuest = channel.join(event.getGuestId(), event.getNickname());
+        channelRepo.saveMember(joinedGuest);
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
@@ -50,7 +50,7 @@ public class Channel extends BaseEntity {
         );
     }
 
-    public void join(final Long guestId, final String nickname) {
+    public ChannelMember join(final Long guestId, final String nickname) {
         if (!hasLeftPeople()) {
             throw new NoLeftPeopleException();
         }
@@ -61,6 +61,7 @@ public class Channel extends BaseEntity {
             throw new DuplicateNicknameException();
         }
         numberOfPeople++;
+        return ChannelMember.ofGuest(getId(), guestId, nickname);
     }
 
     private boolean hasLeftPeople() {

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
@@ -1,6 +1,7 @@
 package com.nailseong.invitation.channel.domain;
 
 import com.nailseong.invitation.channel.exception.InvalidMaxPeopleException;
+import com.nailseong.invitation.channel.exception.NoLeftPeopleException;
 import com.nailseong.invitation.config.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -37,6 +38,17 @@ public class Channel extends BaseEntity {
                 maxPeople,
                 INITIAL_NUMBER_OF_PEOPLE
         );
+    }
+
+    public void join() {
+        if (!hasLeftPeople()) {
+            throw new NoLeftPeopleException();
+        }
+        numberOfPeople++;
+    }
+
+    private boolean hasLeftPeople() {
+        return maxPeople > numberOfPeople;
     }
 
     public boolean isHost(final Long memberId) {

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/Channel.java
@@ -30,20 +30,23 @@ public class Channel extends BaseEntity {
     protected Channel() {
     }
 
-    private Channel(final Long hostId, final int maxPeople, final int numberOfPeople) {
+    public Channel(final Long hostId, final int maxPeople, final int numberOfPeople,
+                   final List<ChannelMember> channelMembers) {
         this.hostId = hostId;
         this.maxPeople = maxPeople;
         this.numberOfPeople = numberOfPeople;
+        this.channelMembers = channelMembers;
     }
 
-    public static Channel ofNew(final Long hostId, final int maxPeople) {
+    public static Channel ofNew(final Long hostId, final int maxPeople, final ChannelMember host) {
         if (maxPeople < 2) {
             throw new InvalidMaxPeopleException();
         }
         return new Channel(
                 hostId,
                 maxPeople,
-                INITIAL_NUMBER_OF_PEOPLE
+                INITIAL_NUMBER_OF_PEOPLE,
+                List.of(host)
         );
     }
 
@@ -90,7 +93,11 @@ public class Channel extends BaseEntity {
         return numberOfPeople;
     }
 
-    public void setChannelMembers(final List<ChannelMember> channelMembers) {
+    public List<ChannelMember> getChannelMembers() {
+        return channelMembers;
+    }
+
+    void setChannelMembers(final List<ChannelMember> channelMembers) {
         this.channelMembers = channelMembers;
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
@@ -25,6 +25,10 @@ public class ChannelMember extends BaseEntity {
     protected ChannelMember() {
     }
 
+    private ChannelMember(final Long memberId, final MemberRole role, final String nickname) {
+        this(null, memberId, role, nickname);
+    }
+
     private ChannelMember(final Long channelId, final Long memberId, final MemberRole role, final String nickname) {
         this.channelId = channelId;
         this.memberId = memberId;
@@ -34,7 +38,6 @@ public class ChannelMember extends BaseEntity {
 
     public static ChannelMember ofHost(final Long hostId, final String nickname) {
         return new ChannelMember(
-                null,
                 hostId,
                 MemberRole.HOST,
                 nickname

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
@@ -54,6 +54,10 @@ public class ChannelMember extends BaseEntity {
         return this.memberId.equals(memberId);
     }
 
+    public boolean isSameNickname(final String nickname) {
+        return this.nickname.equals(nickname);
+    }
+
     public Long getChannelId() {
         return channelId;
     }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
@@ -32,9 +32,9 @@ public class ChannelMember extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public static ChannelMember ofHost(final Long channelId, final Long hostId, final String nickname) {
+    public static ChannelMember ofHost(final Long hostId, final String nickname) {
         return new ChannelMember(
-                channelId,
+                null,
                 hostId,
                 MemberRole.HOST,
                 nickname
@@ -60,6 +60,10 @@ public class ChannelMember extends BaseEntity {
 
     public Long getChannelId() {
         return channelId;
+    }
+
+    void setChannelId(final Long channelId) {
+        this.channelId = channelId;
     }
 
     public Long getMemberId() {

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMember.java
@@ -41,6 +41,19 @@ public class ChannelMember extends BaseEntity {
         );
     }
 
+    public static ChannelMember ofGuest(final Long channelId, final Long guestId, final String nickname) {
+        return new ChannelMember(
+                channelId,
+                guestId,
+                MemberRole.GUEST,
+                nickname
+        );
+    }
+
+    public boolean isSameMember(final Long memberId) {
+        return this.memberId.equals(memberId);
+    }
+
     public Long getChannelId() {
         return channelId;
     }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMemberRepository.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelMemberRepository.java
@@ -1,6 +1,9 @@
 package com.nailseong.invitation.channel.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChannelMemberRepository extends JpaRepository<ChannelMember, Long> {
+
+    List<ChannelMember> findAllByChannelId(final Long channelId);
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelRepository.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/domain/ChannelRepository.java
@@ -1,6 +1,44 @@
 package com.nailseong.invitation.channel.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.nailseong.invitation.channel.exception.ChannelNotFoundException;
+import com.nailseong.invitation.channel.infrastructure.ChannelEntityRepository;
+import com.nailseong.invitation.channel.infrastructure.ChannelMemberRepository;
+import java.util.List;
+import org.springframework.stereotype.Repository;
 
-public interface ChannelRepository extends JpaRepository<Channel, Long> {
+@Repository
+public class ChannelRepository {
+
+    private final ChannelEntityRepository channelRepo;
+    private final ChannelMemberRepository channelMemberRepo;
+
+    public ChannelRepository(final ChannelEntityRepository channelRepo,
+                             final ChannelMemberRepository channelMemberRepo) {
+        this.channelRepo = channelRepo;
+        this.channelMemberRepo = channelMemberRepo;
+    }
+
+    public Channel getById(final Long channelId) {
+        final Channel channel = channelRepo.findById(channelId)
+                .orElseThrow(ChannelNotFoundException::new);
+        final List<ChannelMember> channelMembers = channelMemberRepo.findAllByChannelId(channelId);
+        channel.setChannelMembers(channelMembers);
+        return channel;
+    }
+
+    public Channel saveChannel(final Channel channel) {
+        final Channel savedChannel = channelRepo.save(channel);
+        savedChannel.getChannelMembers()
+                .forEach(it -> persistMember(savedChannel.getId(), it));
+        return savedChannel;
+    }
+
+    private void persistMember(final Long channelId, final ChannelMember channelMember) {
+        channelMember.setChannelId(channelId);
+        saveMember(channelMember);
+    }
+
+    public ChannelMember saveMember(final ChannelMember channelMember) {
+        return channelMemberRepo.save(channelMember);
+    }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/AlreadyJoinException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/AlreadyJoinException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class AlreadyJoinException extends BadRequestException {
 
-    private static final String MESSAGE = "이미 참여한 채널입니다.";
+    public static final String MESSAGE = "이미 참여한 채널입니다.";
 
     public AlreadyJoinException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/AlreadyJoinException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/AlreadyJoinException.java
@@ -1,0 +1,12 @@
+package com.nailseong.invitation.channel.exception;
+
+import com.nailseong.invitation.exception.BadRequestException;
+
+public class AlreadyJoinException extends BadRequestException {
+
+    private static final String MESSAGE = "이미 참여한 채널입니다.";
+
+    public AlreadyJoinException() {
+        super(MESSAGE);
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/DuplicateNicknameException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.nailseong.invitation.channel.exception;
+
+import com.nailseong.invitation.exception.BadRequestException;
+
+public class DuplicateNicknameException extends BadRequestException {
+
+    public static final String MESSAGE = "닉네임이 중복됩니다.";
+
+    public DuplicateNicknameException() {
+        super(MESSAGE);
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/InvalidMaxPeopleException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/InvalidMaxPeopleException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class InvalidMaxPeopleException extends BadRequestException {
 
-    private final static String MESSAGE = "최대 인원이 유효하지 않습니다.";
+    public final static String MESSAGE = "최대 인원이 유효하지 않습니다.";
 
     public InvalidMaxPeopleException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/NoLeftPeopleException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/NoLeftPeopleException.java
@@ -1,0 +1,12 @@
+package com.nailseong.invitation.channel.exception;
+
+import com.nailseong.invitation.exception.BadRequestException;
+
+public class NoLeftPeopleException extends BadRequestException {
+
+    public static final String MESSAGE = "채널이 가득 찼습니다.";
+
+    public NoLeftPeopleException() {
+        super(MESSAGE);
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/NotHostException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/exception/NotHostException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class NotHostException extends BadRequestException {
 
-    private static final String MESSAGE = "방장 권한이 필요합니다.";
+    public static final String MESSAGE = "방장 권한이 필요합니다.";
 
     public NotHostException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/infrastructure/ChannelEntityRepository.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/infrastructure/ChannelEntityRepository.java
@@ -1,0 +1,7 @@
+package com.nailseong.invitation.channel.infrastructure;
+
+import com.nailseong.invitation.channel.domain.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelEntityRepository extends JpaRepository<Channel, Long> {
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/infrastructure/ChannelMemberRepository.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/infrastructure/ChannelMemberRepository.java
@@ -1,5 +1,6 @@
-package com.nailseong.invitation.channel.domain;
+package com.nailseong.invitation.channel.infrastructure;
 
+import com.nailseong.invitation.channel.domain.ChannelMember;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/invitation-domain/src/main/java/com/nailseong/invitation/channel/support/ChannelAndMemberValidator.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/channel/support/ChannelAndMemberValidator.java
@@ -2,7 +2,6 @@ package com.nailseong.invitation.channel.support;
 
 import com.nailseong.invitation.channel.domain.Channel;
 import com.nailseong.invitation.channel.domain.ChannelRepository;
-import com.nailseong.invitation.channel.exception.ChannelNotFoundException;
 import com.nailseong.invitation.channel.exception.NotHostException;
 import java.util.Arrays;
 import org.aspectj.lang.JoinPoint;
@@ -23,8 +22,7 @@ public class ChannelAndMemberValidator {
     @Before("@annotation(com.nailseong.invitation.channel.support.HostOnly)")
     public void validate(final JoinPoint joinPoint) {
         final ChannelAndMember channelAndMember = getChannelAndMember(joinPoint);
-        final Channel channel = channelRepo.findById(channelAndMember.channelId())
-                .orElseThrow(ChannelNotFoundException::new);
+        final Channel channel = channelRepo.getById(channelAndMember.channelId());
         if (!channel.isHost(channelAndMember.memberId())) {
             throw new NotHostException();
         }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
@@ -43,6 +43,6 @@ public class InvitationService {
                 .orElseThrow(InvalidCodeException::new);
         // TODO: 2022/12/09 이미 채널에 참여한 경우 예외
         // TODO: 2022/12/09 닉네임 중복 검사
-        invitation.use(info.now());
+        invitation.use(info.now(), info.memberId(), info.nickname());
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
@@ -3,7 +3,7 @@ package com.nailseong.invitation.invitation.application;
 import com.nailseong.invitation.channel.support.ChannelAndMember;
 import com.nailseong.invitation.channel.support.HostOnly;
 import com.nailseong.invitation.invitation.application.dto.InvitationInfo;
-import com.nailseong.invitation.invitation.application.dto.JoinByInvitationInfo;
+import com.nailseong.invitation.invitation.application.dto.UseInvitationInfo;
 import com.nailseong.invitation.invitation.domain.Invitation;
 import com.nailseong.invitation.invitation.domain.InvitationRepository;
 import com.nailseong.invitation.invitation.exception.InvalidCodeException;
@@ -38,7 +38,7 @@ public class InvitationService {
         return invitation.getCode();
     }
 
-    public void joinByInvitation(final JoinByInvitationInfo info) {
+    public void useInvitation(final UseInvitationInfo info) {
         final Invitation invitation = invitationRepo.findByCode(info.invitationCode())
                 .orElseThrow(InvalidCodeException::new);
         // TODO: 2022/12/09 이미 채널에 참여한 경우 예외

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
@@ -3,8 +3,10 @@ package com.nailseong.invitation.invitation.application;
 import com.nailseong.invitation.channel.support.ChannelAndMember;
 import com.nailseong.invitation.channel.support.HostOnly;
 import com.nailseong.invitation.invitation.application.dto.InvitationInfo;
+import com.nailseong.invitation.invitation.application.dto.JoinByInvitationInfo;
 import com.nailseong.invitation.invitation.domain.Invitation;
 import com.nailseong.invitation.invitation.domain.InvitationRepository;
+import com.nailseong.invitation.invitation.exception.InvalidCodeException;
 import com.nailseong.invitation.util.RandomStringGenerator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +36,13 @@ public class InvitationService {
                 code
         ));
         return invitation.getCode();
+    }
+
+    public void joinByInvitation(final JoinByInvitationInfo info) {
+        final Invitation invitation = invitationRepo.findByCode(info.invitationCode())
+                .orElseThrow(InvalidCodeException::new);
+        // TODO: 2022/12/09 이미 채널에 참여한 경우 예외
+        // TODO: 2022/12/09 닉네임 중복 검사
+        invitation.use(info.now());
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/InvitationService.java
@@ -41,8 +41,6 @@ public class InvitationService {
     public void useInvitation(final UseInvitationInfo info) {
         final Invitation invitation = invitationRepo.findByCode(info.invitationCode())
                 .orElseThrow(InvalidCodeException::new);
-        // TODO: 2022/12/09 이미 채널에 참여한 경우 예외
-        // TODO: 2022/12/09 닉네임 중복 검사
         invitation.use(info.now(), info.memberId(), info.nickname());
     }
 }

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/dto/JoinByInvitationInfo.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/dto/JoinByInvitationInfo.java
@@ -1,0 +1,10 @@
+package com.nailseong.invitation.invitation.application.dto;
+
+import java.time.LocalDateTime;
+
+public record JoinByInvitationInfo(
+        String invitationCode,
+        String nickname,
+        Long memberId,
+        LocalDateTime now) {
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/dto/UseInvitationInfo.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/application/dto/UseInvitationInfo.java
@@ -2,7 +2,7 @@ package com.nailseong.invitation.invitation.application.dto;
 
 import java.time.LocalDateTime;
 
-public record JoinByInvitationInfo(
+public record UseInvitationInfo(
         String invitationCode,
         String nickname,
         Long memberId,

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/Invitation.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/Invitation.java
@@ -1,6 +1,7 @@
 package com.nailseong.invitation.invitation.domain;
 
 import com.nailseong.invitation.config.BaseEntity;
+import com.nailseong.invitation.event.Events;
 import com.nailseong.invitation.invitation.exception.InvalidCodeException;
 import com.nailseong.invitation.invitation.exception.InvalidExpireAfterException;
 import com.nailseong.invitation.invitation.exception.InvalidMaxUsesException;
@@ -43,7 +44,7 @@ public class Invitation extends BaseEntity {
         setCode(code);
     }
 
-    public void use(final LocalDateTime joinTime) {
+    public void use(final LocalDateTime joinTime, final Long guestId, final String nickname) {
         if (expireAfter.isBefore(joinTime)) {
             throw new InvitationExpireException();
         }
@@ -51,6 +52,7 @@ public class Invitation extends BaseEntity {
             throw new NoLeftUsesException();
         }
         numberOfUses++;
+        Events.raise(new InvitationUsedEvent(channelId, guestId, nickname));
     }
 
     private boolean hasLeftUses() {

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/Invitation.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/Invitation.java
@@ -4,6 +4,8 @@ import com.nailseong.invitation.config.BaseEntity;
 import com.nailseong.invitation.invitation.exception.InvalidCodeException;
 import com.nailseong.invitation.invitation.exception.InvalidExpireAfterException;
 import com.nailseong.invitation.invitation.exception.InvalidMaxUsesException;
+import com.nailseong.invitation.invitation.exception.InvitationExpireException;
+import com.nailseong.invitation.invitation.exception.NoLeftUsesException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import java.time.LocalDateTime;
@@ -11,10 +13,9 @@ import java.time.LocalDateTime;
 @Entity
 public class Invitation extends BaseEntity {
 
+    public static final int CODE_LENGTH = 6;
     private static final int INITIAL_NUMBER_OF_USES = 0;
     private static final int MIN_MAX_USES = 1;
-    public static final int CODE_LENGTH = 6;
-
     @Column(nullable = false)
     private Long channelId;
 
@@ -40,6 +41,20 @@ public class Invitation extends BaseEntity {
         setMaxUses(maxUses);
         this.numberOfUses = INITIAL_NUMBER_OF_USES;
         setCode(code);
+    }
+
+    public void use(final LocalDateTime joinTime) {
+        if (expireAfter.isBefore(joinTime)) {
+            throw new InvitationExpireException();
+        }
+        if (!hasLeftUses()) {
+            throw new NoLeftUsesException();
+        }
+        numberOfUses++;
+    }
+
+    private boolean hasLeftUses() {
+        return maxUses > numberOfUses;
     }
 
     public Long getChannelId() {

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/InvitationUsedEvent.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/domain/InvitationUsedEvent.java
@@ -1,0 +1,28 @@
+package com.nailseong.invitation.invitation.domain;
+
+import com.nailseong.invitation.event.Event;
+
+public class InvitationUsedEvent extends Event {
+
+    private final Long channelId;
+    private final Long guestId;
+    private final String nickname;
+
+    public InvitationUsedEvent(final Long channelId, final Long guestId, final String nickname) {
+        this.channelId = channelId;
+        this.guestId = guestId;
+        this.nickname = nickname;
+    }
+
+    public Long getChannelId() {
+        return channelId;
+    }
+
+    public Long getGuestId() {
+        return guestId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidCodeException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidCodeException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class InvalidCodeException extends BadRequestException {
 
-    private static final String MESSAGE = "초대장의 코드가 유효하지 않습니다.";
+    public static final String MESSAGE = "초대장의 코드가 유효하지 않습니다.";
 
     public InvalidCodeException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidExpireAfterException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidExpireAfterException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class InvalidExpireAfterException extends BadRequestException {
 
-    private static final String MESSAGE = "만료 기간이 유효하지 않습니다.";
+    public static final String MESSAGE = "만료 기간이 유효하지 않습니다.";
 
     public InvalidExpireAfterException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidMaxUsesException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvalidMaxUsesException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class InvalidMaxUsesException extends BadRequestException {
 
-    private final static String MESSAGE = "초대장의 최대 사용 횟수가 유효하지 않습니다.";
+    public final static String MESSAGE = "초대장의 최대 사용 횟수가 유효하지 않습니다.";
 
     public InvalidMaxUsesException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvitationExpireException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvitationExpireException.java
@@ -1,0 +1,12 @@
+package com.nailseong.invitation.invitation.exception;
+
+import com.nailseong.invitation.exception.BadRequestException;
+
+public class InvitationExpireException extends BadRequestException {
+
+    private static final String MESSAGE = "초대장이 만료되었습니다.";
+
+    public InvitationExpireException() {
+        super(MESSAGE);
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvitationExpireException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/InvitationExpireException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class InvitationExpireException extends BadRequestException {
 
-    private static final String MESSAGE = "초대장이 만료되었습니다.";
+    public static final String MESSAGE = "초대장이 만료되었습니다.";
 
     public InvitationExpireException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/NoLeftUsesException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/NoLeftUsesException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class NoLeftUsesException extends BadRequestException {
 
-    private static final String MESSAGE = "초대장에 사용 가능 횟수가 남아있지 않습니다.";
+    public static final String MESSAGE = "초대장에 사용 가능 횟수가 남아있지 않습니다.";
 
     public NoLeftUsesException() {
         super(MESSAGE);

--- a/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/NoLeftUsesException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/invitation/exception/NoLeftUsesException.java
@@ -1,0 +1,12 @@
+package com.nailseong.invitation.invitation.exception;
+
+import com.nailseong.invitation.exception.BadRequestException;
+
+public class NoLeftUsesException extends BadRequestException {
+
+    private static final String MESSAGE = "초대장에 사용 가능 횟수가 남아있지 않습니다.";
+
+    public NoLeftUsesException() {
+        super(MESSAGE);
+    }
+}

--- a/invitation-domain/src/main/java/com/nailseong/invitation/member/exception/DuplicateUsernameException.java
+++ b/invitation-domain/src/main/java/com/nailseong/invitation/member/exception/DuplicateUsernameException.java
@@ -4,7 +4,7 @@ import com.nailseong.invitation.exception.BadRequestException;
 
 public class DuplicateUsernameException extends BadRequestException {
 
-    private static final String MESSAGE = "이미 사용중인 사용자 이름입니다.";
+    public static final String MESSAGE = "이미 사용중인 사용자 이름입니다.";
 
     public DuplicateUsernameException() {
         super(MESSAGE);

--- a/invitation-domain/src/test/java/com/nailseong/invitation/channel/support/ChannelAndMemberValidatorTest.java
+++ b/invitation-domain/src/test/java/com/nailseong/invitation/channel/support/ChannelAndMemberValidatorTest.java
@@ -6,10 +6,10 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.nailseong.invitation.channel.domain.Channel;
+import com.nailseong.invitation.channel.domain.ChannelMember;
 import com.nailseong.invitation.channel.domain.ChannelRepository;
 import com.nailseong.invitation.channel.exception.ChannelNotFoundException;
 import com.nailseong.invitation.channel.exception.NotHostException;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -59,9 +59,10 @@ class ChannelAndMemberValidatorTest {
         @DisplayName("성공한다.")
         void success() {
             // given
-            final Channel channel = Channel.ofNew(hostId, 2);
-            given(channelRepo.findById(anyLong()))
-                    .willReturn(Optional.of(channel));
+            final ChannelMember host = ChannelMember.ofHost(hostId, "rick");
+            final Channel channel = Channel.ofNew(hostId, 2, host);
+            given(channelRepo.getById(anyLong()))
+                    .willReturn(channel);
 
             final ChannelAndMember channelAndMember = new ChannelAndMember(7L, hostId);
 
@@ -78,8 +79,8 @@ class ChannelAndMemberValidatorTest {
             @DisplayName("채널이 존재하지 않는 경우이다.")
             void notExistChannel() {
                 // given
-                given(channelRepo.findById(anyLong()))
-                        .willReturn(Optional.empty());
+                given(channelRepo.getById(anyLong()))
+                        .willThrow(new ChannelNotFoundException());
 
                 final ChannelAndMember channelAndMember = new ChannelAndMember(7L, hostId);
 
@@ -92,9 +93,10 @@ class ChannelAndMemberValidatorTest {
             @DisplayName("호스트가 아닌 경우이다.")
             void notHost() {
                 // given
-                final Channel channel = Channel.ofNew(hostId, 2);
-                given(channelRepo.findById(anyLong()))
-                        .willReturn(Optional.of(channel));
+                final ChannelMember host = ChannelMember.ofHost(hostId, "rick");
+                final Channel channel = Channel.ofNew(hostId, 2, host);
+                given(channelRepo.getById(anyLong()))
+                        .willReturn(channel);
 
                 final ChannelAndMember channelAndMember = new ChannelAndMember(7L, hostId + 1);
 

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
@@ -5,12 +5,14 @@ import com.nailseong.invitation.authentication.support.Verified;
 import com.nailseong.invitation.channel.support.ChannelAndMember;
 import com.nailseong.invitation.invitation.application.InvitationService;
 import com.nailseong.invitation.invitation.application.dto.InvitationInfo;
+import com.nailseong.invitation.invitation.application.dto.JoinByInvitationInfo;
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
 import com.nailseong.invitation.invitation.dto.CreateInvitationResponse;
 import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,8 +47,14 @@ public class InvitationController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/{invitationCode}")
     public void joinByInvitation(@RequestBody @Valid final JoinByInvitationRequest request,
-                                 final String invitationCode,
+                                 @PathVariable final String invitationCode,
                                  @Verified final LoginSession loginSession) {
-        // TODO: 2022/12/09 implement 
+        final JoinByInvitationInfo joinByInvitationInfo = new JoinByInvitationInfo(
+                invitationCode,
+                request.nickname(),
+                loginSession.memberId(),
+                LocalDateTime.now()
+        );
+        invitationService.joinByInvitation(joinByInvitationInfo);
     }
 }

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
@@ -7,11 +7,14 @@ import com.nailseong.invitation.invitation.application.InvitationService;
 import com.nailseong.invitation.invitation.application.dto.InvitationInfo;
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
 import com.nailseong.invitation.invitation.dto.CreateInvitationResponse;
+import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,5 +40,13 @@ public class InvitationController {
         final ChannelAndMember channelAndMember = new ChannelAndMember(request.channelId(), loginSession.memberId());
         final String invitationCode = invitationService.createInvitation(invitationInfo, channelAndMember);
         return new CreateInvitationResponse(HOST + invitationCode);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/{invitationCode}")
+    public void joinByInvitation(@RequestBody @Valid final JoinByInvitationRequest request,
+                                 final String invitationCode,
+                                 @Verified final LoginSession loginSession) {
+        // TODO: 2022/12/09 implement 
     }
 }

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/InvitationController.java
@@ -5,10 +5,10 @@ import com.nailseong.invitation.authentication.support.Verified;
 import com.nailseong.invitation.channel.support.ChannelAndMember;
 import com.nailseong.invitation.invitation.application.InvitationService;
 import com.nailseong.invitation.invitation.application.dto.InvitationInfo;
-import com.nailseong.invitation.invitation.application.dto.JoinByInvitationInfo;
+import com.nailseong.invitation.invitation.application.dto.UseInvitationInfo;
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
 import com.nailseong.invitation.invitation.dto.CreateInvitationResponse;
-import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
+import com.nailseong.invitation.invitation.dto.UseInvitationRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
@@ -46,15 +46,15 @@ public class InvitationController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/{invitationCode}")
-    public void joinByInvitation(@RequestBody @Valid final JoinByInvitationRequest request,
-                                 @PathVariable final String invitationCode,
-                                 @Verified final LoginSession loginSession) {
-        final JoinByInvitationInfo joinByInvitationInfo = new JoinByInvitationInfo(
+    public void useInvitation(@RequestBody @Valid final UseInvitationRequest request,
+                              @PathVariable final String invitationCode,
+                              @Verified final LoginSession loginSession) {
+        final UseInvitationInfo useInvitationInfo = new UseInvitationInfo(
                 invitationCode,
                 request.nickname(),
                 loginSession.memberId(),
                 LocalDateTime.now()
         );
-        invitationService.joinByInvitation(joinByInvitationInfo);
+        invitationService.useInvitation(useInvitationInfo);
     }
 }

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/CreateInvitationRequest.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/CreateInvitationRequest.java
@@ -1,18 +1,14 @@
 package com.nailseong.invitation.invitation.dto;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
 
 public record CreateInvitationRequest(
         @NotNull
         Long channelId,
 
-        @Future
         LocalDateTime expireAfter,
 
-        @Positive
         int maxUses
 ) {
 }

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/JoinByInvitationRequest.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/JoinByInvitationRequest.java
@@ -1,0 +1,9 @@
+package com.nailseong.invitation.invitation.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record JoinByInvitationRequest(
+        @NotEmpty
+        String nickname
+) {
+}

--- a/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/UseInvitationRequest.java
+++ b/invitation-ui/src/main/java/com/nailseong/invitation/invitation/dto/UseInvitationRequest.java
@@ -2,7 +2,7 @@ package com.nailseong.invitation.invitation.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 
-public record JoinByInvitationRequest(
+public record UseInvitationRequest(
         @NotEmpty
         String nickname
 ) {

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
@@ -5,11 +5,14 @@ import static org.springframework.http.HttpHeaders.LOCATION;
 
 import com.nailseong.invitation.authentication.presentation.dto.LoginRequest;
 import com.nailseong.invitation.channel.dto.CreateChannelRequest;
+import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
+import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
 import com.nailseong.invitation.member.dto.SignupRequest;
 import com.nailseong.invitation.util.DatabaseCleaner;
 import io.restassured.RestAssured;
 import io.restassured.http.Method;
 import io.restassured.response.ValidatableResponse;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,6 +61,26 @@ abstract class AcceptanceTest {
                 .extract()
                 .header(LOCATION)
                 .split("/")[3]);
+    }
+
+    protected String createInvitation(final String sessionId, final Long channelId, final LocalDateTime expireAfter) {
+        final var request = new CreateInvitationRequest(channelId, expireAfter, 1);
+        return url("/api/invitations")
+                .body(request)
+                .method(POST)
+                .sendWithoutLog(sessionId)
+                .extract()
+                .<String>path("invitationUrl")
+                .split("https://invitation.nailseong.com/")[1];
+    }
+
+    protected void joinByInvitation(final String sessionId, final String invitationCode) {
+        final var request = new JoinByInvitationRequest("nailseong");
+        url("/api/invitations/" + invitationCode)
+                .body(request)
+                .method(POST)
+                .sendWithoutLog(sessionId);
+
     }
 
     protected UrlBuilder url(final String url) {

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
@@ -64,7 +64,12 @@ abstract class AcceptanceTest {
     }
 
     protected String createInvitation(final String sessionId, final Long channelId, final LocalDateTime expireAfter) {
-        final var request = new CreateInvitationRequest(channelId, expireAfter, 1);
+        return createInvitation(sessionId, channelId, expireAfter, 1);
+    }
+
+    protected String createInvitation(final String sessionId, final Long channelId, final LocalDateTime expireAfter,
+                                      final int maxUses) {
+        final var request = new CreateInvitationRequest(channelId, expireAfter, maxUses);
         return url("/api/invitations")
                 .body(request)
                 .method(POST)

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
@@ -53,7 +53,11 @@ abstract class AcceptanceTest {
     }
 
     protected Long createChannel(final String sessionId) {
-        final var request = new CreateChannelRequest("rick", 2);
+        return createChannel(sessionId, 2);
+    }
+
+    protected Long createChannel(final String sessionId, final int maxPeople) {
+        final var request = new CreateChannelRequest("rick", maxPeople);
         return Long.valueOf(url("/api/channels")
                 .body(request)
                 .method(POST)
@@ -79,8 +83,8 @@ abstract class AcceptanceTest {
                 .split("https://invitation.nailseong.com/")[1];
     }
 
-    protected void useInvitation(final String sessionId, final String invitationCode) {
-        final var request = new UseInvitationRequest("nailseong");
+    protected void useInvitation(final String sessionId, final String invitationCode, final String nickname) {
+        final var request = new UseInvitationRequest(nickname);
         url("/api/invitations/" + invitationCode)
                 .body(request)
                 .method(POST)

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/AcceptanceTest.java
@@ -6,7 +6,7 @@ import static org.springframework.http.HttpHeaders.LOCATION;
 import com.nailseong.invitation.authentication.presentation.dto.LoginRequest;
 import com.nailseong.invitation.channel.dto.CreateChannelRequest;
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
-import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
+import com.nailseong.invitation.invitation.dto.UseInvitationRequest;
 import com.nailseong.invitation.member.dto.SignupRequest;
 import com.nailseong.invitation.util.DatabaseCleaner;
 import io.restassured.RestAssured;
@@ -74,8 +74,8 @@ abstract class AcceptanceTest {
                 .split("https://invitation.nailseong.com/")[1];
     }
 
-    protected void joinByInvitation(final String sessionId, final String invitationCode) {
-        final var request = new JoinByInvitationRequest("nailseong");
+    protected void useInvitation(final String sessionId, final String invitationCode) {
+        final var request = new UseInvitationRequest("nailseong");
         url("/api/invitations/" + invitationCode)
                 .body(request)
                 .method(POST)

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/ChannelAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/ChannelAcceptanceTest.java
@@ -1,9 +1,11 @@
 package com.nailseong.invitation.acceptance;
 
 import static io.restassured.http.Method.POST;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.nailseong.invitation.channel.dto.CreateChannelRequest;
+import com.nailseong.invitation.channel.exception.InvalidMaxPeopleException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,7 +59,8 @@ class ChannelAcceptanceTest extends AcceptanceTest {
                         .send(sessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(InvalidMaxPeopleException.MESSAGE));
             }
         }
     }

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
@@ -8,7 +8,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
-import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
+import com.nailseong.invitation.invitation.dto.UseInvitationRequest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -115,8 +115,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("초대장을 통한 채널 참가 기능이")
-    class Join {
+    @DisplayName("초대장 사용하기 기능이")
+    class Use {
 
         private static final String URL_PREFIX = "/api/invitations/";
 
@@ -133,7 +133,7 @@ class InvitationAcceptanceTest extends AcceptanceTest {
         void success() {
             // given
             final String invitationCode = createInvitation(sessionId, channelId, LocalDateTime.now().plusDays(1));
-            final var request = new JoinByInvitationRequest("nailseong");
+            final var request = new UseInvitationRequest("nailseong");
 
             // when
             final var response = url(URL_PREFIX + invitationCode)
@@ -153,7 +153,7 @@ class InvitationAcceptanceTest extends AcceptanceTest {
             @DisplayName("초대장에 해당하는 채널이 존재하지 않는 경우이다.")
             void notExistChannel() {
                 // given
-                final var request = new JoinByInvitationRequest("nailseong");
+                final var request = new UseInvitationRequest("nailseong");
 
                 // when
                 final var response = url(URL_PREFIX + "x0x0X0")
@@ -171,7 +171,7 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                 // given
                 final LocalDateTime expireAfter = LocalDateTime.now().plusSeconds(1L);
                 final String invitationCode = createInvitation(sessionId, channelId, expireAfter);
-                final var request = new JoinByInvitationRequest("nailseong");
+                final var request = new UseInvitationRequest("nailseong");
 
                 Thread.sleep(1100);
 
@@ -191,9 +191,9 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                 // given
                 final LocalDateTime expireAfter = LocalDateTime.now().plusDays(1L);
                 final String invitationCode = createInvitation(sessionId, channelId, expireAfter);
-                final var request = new JoinByInvitationRequest("nailseong");
+                final var request = new UseInvitationRequest("nailseong");
 
-                joinByInvitation(guestSessionId, invitationCode);
+                useInvitation(guestSessionId, invitationCode);
 
                 // when
                 final var response = url(URL_PREFIX + invitationCode)

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
@@ -8,9 +8,16 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
+import com.nailseong.invitation.channel.exception.AlreadyJoinException;
 import com.nailseong.invitation.channel.exception.DuplicateNicknameException;
+import com.nailseong.invitation.channel.exception.NotHostException;
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
 import com.nailseong.invitation.invitation.dto.UseInvitationRequest;
+import com.nailseong.invitation.invitation.exception.InvalidCodeException;
+import com.nailseong.invitation.invitation.exception.InvalidExpireAfterException;
+import com.nailseong.invitation.invitation.exception.InvalidMaxUsesException;
+import com.nailseong.invitation.invitation.exception.InvitationExpireException;
+import com.nailseong.invitation.invitation.exception.NoLeftUsesException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -76,7 +83,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(sessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(InvalidMaxUsesException.MESSAGE));
             }
 
             @Test
@@ -92,7 +100,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(sessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(InvalidExpireAfterException.MESSAGE));
             }
 
             @Test
@@ -111,7 +120,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(guestSessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(NotHostException.MESSAGE));
             }
         }
     }
@@ -164,7 +174,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(guestSessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(InvalidCodeException.MESSAGE));
             }
 
             @Test
@@ -184,7 +195,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(guestSessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(InvitationExpireException.MESSAGE));
             }
 
             @Test
@@ -204,7 +216,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(guestSessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(NoLeftUsesException.MESSAGE));
             }
 
             @Test
@@ -224,7 +237,8 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                         .send(guestSessionId);
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(AlreadyJoinException.MESSAGE));
             }
 
             @Test

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
@@ -204,6 +204,26 @@ class InvitationAcceptanceTest extends AcceptanceTest {
                 // then
                 response.statusCode(BAD_REQUEST.value());
             }
+
+            @Test
+            @DisplayName("이미 가입한 채널인 경우이다.")
+            void alreadyJoin() {
+                // given
+                final LocalDateTime expireAfter = LocalDateTime.now().plusDays(1L);
+                final String invitationCode = createInvitation(sessionId, channelId, expireAfter, 2);
+                final var request = new UseInvitationRequest("nailseong");
+
+                useInvitation(guestSessionId, invitationCode);
+
+                // when
+                final var response = url(URL_PREFIX + invitationCode)
+                        .body(request)
+                        .method(POST)
+                        .send(guestSessionId);
+
+                // then
+                response.statusCode(BAD_REQUEST.value());
+            }
         }
     }
 }

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/InvitationAcceptanceTest.java
@@ -4,9 +4,11 @@ import static io.restassured.http.Method.POST;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.nailseong.invitation.invitation.dto.CreateInvitationRequest;
+import com.nailseong.invitation.invitation.dto.JoinByInvitationRequest;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,22 +18,25 @@ import org.junit.jupiter.api.Test;
 @DisplayName("초대장 인수 테스트")
 class InvitationAcceptanceTest extends AcceptanceTest {
 
+    private static final String USERNAME = "ilseong";
+
+    private String sessionId;
+    private Long channelId;
+
+    @Override
+    @BeforeEach
+    void setUp() {
+        super.setUp();
+        signup(USERNAME);
+        sessionId = login(USERNAME);
+        channelId = createChannel(sessionId);
+    }
+
     @Nested
     @DisplayName("초대장 생성 기능이")
     class Create {
 
-        private String sessionId;
-        private Long channelId;
-
-        @BeforeEach
-        void setUp() {
-            signup(USERNAME);
-            sessionId = login(USERNAME);
-            channelId = createChannel(sessionId);
-        }
-
         private static final String URL = "/api/invitations";
-        private static final String USERNAME = "ilseong";
         private static final String HOST = "https://invitation.nailseong.com/";
 
         @Test
@@ -99,6 +104,99 @@ class InvitationAcceptanceTest extends AcceptanceTest {
 
                 // when
                 final var response = url(URL)
+                        .body(request)
+                        .method(POST)
+                        .send(guestSessionId);
+
+                // then
+                response.statusCode(BAD_REQUEST.value());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("초대장을 통한 채널 참가 기능이")
+    class Join {
+
+        private static final String URL_PREFIX = "/api/invitations/";
+
+        private String guestSessionId;
+
+        @BeforeEach
+        void setUp() {
+            signup("rick");
+            guestSessionId = login("rick");
+        }
+
+        @Test
+        @DisplayName("성공한다.")
+        void success() {
+            // given
+            final String invitationCode = createInvitation(sessionId, channelId, LocalDateTime.now().plusDays(1));
+            final var request = new JoinByInvitationRequest("nailseong");
+
+            // when
+            final var response = url(URL_PREFIX + invitationCode)
+                    .body(request)
+                    .method(POST)
+                    .send(guestSessionId);
+
+            // then
+            response.statusCode(NO_CONTENT.value());
+        }
+
+        @Nested
+        @DisplayName("실패하는 경우는")
+        class Exception {
+
+            @Test
+            @DisplayName("초대장에 해당하는 채널이 존재하지 않는 경우이다.")
+            void notExistChannel() {
+                // given
+                final var request = new JoinByInvitationRequest("nailseong");
+
+                // when
+                final var response = url(URL_PREFIX + "x0x0X0")
+                        .body(request)
+                        .method(POST)
+                        .send(guestSessionId);
+
+                // then
+                response.statusCode(BAD_REQUEST.value());
+            }
+
+            @Test
+            @DisplayName("만료 기간이 지난 경우이다.")
+            void expireAfter() throws InterruptedException {
+                // given
+                final LocalDateTime expireAfter = LocalDateTime.now().plusSeconds(1L);
+                final String invitationCode = createInvitation(sessionId, channelId, expireAfter);
+                final var request = new JoinByInvitationRequest("nailseong");
+
+                Thread.sleep(1100);
+
+                // when
+                final var response = url(URL_PREFIX + invitationCode)
+                        .body(request)
+                        .method(POST)
+                        .send(guestSessionId);
+
+                // then
+                response.statusCode(BAD_REQUEST.value());
+            }
+
+            @Test
+            @DisplayName("사용 가능 횟수가 남아있지 않는 경우이다.")
+            void leftUses() {
+                // given
+                final LocalDateTime expireAfter = LocalDateTime.now().plusDays(1L);
+                final String invitationCode = createInvitation(sessionId, channelId, expireAfter);
+                final var request = new JoinByInvitationRequest("nailseong");
+
+                joinByInvitation(guestSessionId, invitationCode);
+
+                // when
+                final var response = url(URL_PREFIX + invitationCode)
                         .body(request)
                         .method(POST)
                         .send(guestSessionId);

--- a/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/MemberAcceptanceTest.java
+++ b/invitation-ui/src/test/java/com/nailseong/invitation/acceptance/MemberAcceptanceTest.java
@@ -1,10 +1,12 @@
 package com.nailseong.invitation.acceptance;
 
 import static io.restassured.http.Method.POST;
+import static org.hamcrest.Matchers.is;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.nailseong.invitation.member.dto.SignupRequest;
+import com.nailseong.invitation.member.exception.DuplicateUsernameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -68,7 +70,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         .send();
 
                 // then
-                response.statusCode(BAD_REQUEST.value());
+                response.statusCode(BAD_REQUEST.value())
+                        .body("message", is(DuplicateUsernameException.MESSAGE));
             }
         }
     }


### PR DESCRIPTION
## 작업 내용
- 인수 테스트
- ChannelRepository, ChannelMemberRepository를 infrastructure 계층으로 이동
- ChannelRepository -> `ChannelEntityRepository` 이름 변경
- ChannelEntityRepository, ChannelMemberRepository를 상태로 같는 domain 계층의 `ChannelEntity` 구현
  - `ChannelEntity`는 **채널에 가입한 사용자 리스트가 세팅된 Channel** 객체를 영속화하고 조회한다.
- 초대장 사용 시 `InvitationUsedEvent`를 발행하고 이벤트를 Channel이 처리하도록 구현
  - `Channel`이 `Invitation`을 의존하는 형태

Closes #20 